### PR TITLE
Removed yaml_parse() as that requires the yaml extension. 

### DIFF
--- a/apiproduct_catalog/apiproduct_catalog.module
+++ b/apiproduct_catalog/apiproduct_catalog.module
@@ -159,7 +159,14 @@ function apiproduct_catalog_cron()
     /**
      *  Get all the products in edge and make sure they have the access attribute
      */
-    $apiproducts_in_edge = entity_load("api_product", array(), array('show_private' => TRUE), true);
+    try {
+      $apiproducts_in_edge = entity_load("api_product", array(), array('show_private' => TRUE), true);
+    }
+    catch (Exception $e) {
+      watchdog('apiproduct_catalog', 'There was a problem retrieving the API products, cron run aborted.');
+      return;
+    }
+
     //Sort by created date
     uasort($apiproducts_in_edge, function ($a, $b) {
         if ($a->createdAt == $b->createdAt) {

--- a/apiproduct_catalog/apiproduct_catalog.module
+++ b/apiproduct_catalog/apiproduct_catalog.module
@@ -625,7 +625,27 @@ function apiproduct_catalog_smartdocs_model_import($raw_source, $mime_type, $doc
   }
 
   if($mime_type === 'application/yaml') {
-    $swagger_json = yaml_parse($raw_source);
+
+    // This is pulled directly from the working implemention in the
+    // https://github.com/achieve-internet/smartdocs_extend repo.
+    require_once libraries_get_path('spyc') . '/Spyc.php';
+    try {
+      $swagger_obj = spyc_load($raw_source);
+    }
+    catch (Exception $e) {
+      // Spyc may throw "Too many keys" exception in edge cases where it
+      // fails to parse valid well-formed YAML. This occurs when an object
+      // or array is written in "short syntax" and spans more than one line.
+      // See https://github.com/mustangostang/spyc/issues/30
+      // This same bug also afflicts Symfony\Yaml, though PECL yaml reads
+      // the data correctly (using libyaml).
+      watchdog_exception('smartdocs', $e);
+      drupal_set_message(t('Warning: If your model contains parameter enums, they may not have imported correctly.'), 'warning');
+    }
+  
+    if ($swagger_obj) {
+      $swagger_json = json_encode($swagger_obj);
+    }
   } else {
     $swagger_json = json_decode($raw_source, true);
   }

--- a/apiproduct_catalog/apiproduct_catalog.module
+++ b/apiproduct_catalog/apiproduct_catalog.module
@@ -645,6 +645,7 @@ function apiproduct_catalog_smartdocs_model_import($raw_source, $mime_type, $doc
   
     if ($swagger_obj) {
       $swagger_json = json_encode($swagger_obj);
+      $swagger_json = json_decode($swagger_json, true);
     }
   } else {
     $swagger_json = json_decode($raw_source, true);


### PR DESCRIPTION
Copied over code from a fork (by Achieve) of the smartdocs_extend module which will actually parse the yaml file properly.